### PR TITLE
Fix excessive file generation

### DIFF
--- a/org.sonatype.m2e.mavenarchiver.feature/feature.xml
+++ b/org.sonatype.m2e.mavenarchiver.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.sonatype.m2e.mavenarchiver.feature"
       label="%featureName"
-      version="0.15.0.qualifier"
+      version="0.16.0.qualifier"
       provider-name="%providerName"
       plugin="org.sonatype.m2e.mavenarchiver">
 

--- a/org.sonatype.m2e.mavenarchiver.feature/pom.xml
+++ b/org.sonatype.m2e.mavenarchiver.feature/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.sonatype.m2e.extras</groupId>  
     <artifactId>org.sonatype.m2e.mavenarchiver.parent</artifactId>
-    <version>0.15.0-SNAPSHOT</version>
+    <version>0.16.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.sonatype.m2e.mavenarchiver.feature</artifactId>

--- a/org.sonatype.m2e.mavenarchiver.tests/META-INF/MANIFEST.MF
+++ b/org.sonatype.m2e.mavenarchiver.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests Plug-in
 Bundle-SymbolicName: org.sonatype.m2e.mavenarchiver.tests
-Bundle-Version: 0.15.0.qualifier
+Bundle-Version: 0.16.0.qualifier
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Require-Bundle: org.eclipse.m2e.tests.common;bundle-version="[1.0.0,2.0.0)",
  org.junit;bundle-version="3.8.2",

--- a/org.sonatype.m2e.mavenarchiver.tests/pom.xml
+++ b/org.sonatype.m2e.mavenarchiver.tests/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.sonatype.m2e.extras</groupId>  
     <artifactId>org.sonatype.m2e.mavenarchiver.parent</artifactId>
-    <version>0.15.0-SNAPSHOT</version>
+    <version>0.16.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.sonatype.m2e.mavenarchiver.tests</artifactId>

--- a/org.sonatype.m2e.mavenarchiver/META-INF/MANIFEST.MF
+++ b/org.sonatype.m2e.mavenarchiver/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: m2e connector for the mavenarchiver and pom properties
 Bundle-SymbolicName: org.sonatype.m2e.mavenarchiver;singleton:=true
-Bundle-Version: 0.15.0.qualifier
+Bundle-Version: 0.16.0.qualifier
 Bundle-Vendor: Sonatype, Inc.
 Bundle-RequiredExecutionEnvironment: J2SE-1.5,
  JavaSE-1.6

--- a/org.sonatype.m2e.mavenarchiver/pom.xml
+++ b/org.sonatype.m2e.mavenarchiver/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.sonatype.m2e.extras</groupId>  
     <artifactId>org.sonatype.m2e.mavenarchiver.parent</artifactId>
-    <version>0.15.0-SNAPSHOT</version>
+    <version>0.16.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.sonatype.m2e.mavenarchiver</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>io.tesla.tycho</groupId>
     <artifactId>tycho-support</artifactId>
-    <version>0.0.6</version>
+    <version>0.0.7</version>
   </parent>
   
   <!--
@@ -22,19 +22,20 @@
   -->
   <groupId>org.sonatype.m2e.extras</groupId>  
   <artifactId>org.sonatype.m2e.mavenarchiver.parent</artifactId>
-  <version>0.15.0-SNAPSHOT</version>
+  <version>0.16.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>M2E Maven Archiver Connector</name>
 
   <properties>
     <repositoryPathId>m2eclipse-mavenarchiver</repositoryPathId>
     <p2MetadataName>M2E Maven Archiver Connector</p2MetadataName>
+    <tychoVersion>0.18.0</tychoVersion>
   </properties>  
   
   <repositories>
     <repository>
       <id>m2e-tests</id>
-      <url>https://repository.sonatype.org/content/sites/forge-sites/m2e/1.1.0/N/1.1.0.20120622-0806/</url>
+      <url>http://download.eclipse.org/technology/m2e/releases/</url>
       <layout>p2</layout>
     </repository>      
   </repositories>  


### PR DESCRIPTION
Contains @hwellmann 's (squashed) fix for the maven files being regenerated on *each* incremental build (see https://github.com/tesla/m2eclipse-extras/issues/8)
This causes issues such as https://bugs.eclipse.org/bugs/show_bug.cgi?id=412367 (breaks Glassfish incremental deployment with WTP)

Project version is bumped to 0.16.0-SNAPSHOT and builds against m2e 1.4 with tycho 0.18.0