### PR TITLE
Fix "permission denied" bug for multi-user systems

### DIFF
--- a/org.sonatype.m2e.mavenarchiver/src/org/sonatype/m2e/mavenarchiver/internal/AbstractMavenArchiverConfigurator.java
+++ b/org.sonatype.m2e.mavenarchiver/src/org/sonatype/m2e/mavenarchiver/internal/AbstractMavenArchiverConfigurator.java
@@ -742,11 +742,14 @@ private static final String MANIFEST_ENTRIES_NODE = "manifestEntries";
    * Generates a temporary file in the system temporary folder for a given artifact
    * @param localRepo the local repository used to compute the file path
    * @param artifact the artifact to generate a temporary file for
-   * @return a temporary file sitting under ${"java.io.tmpdir"}/fakerepo/${groupid}/{artifactid}/${version}/
+   * @return a temporary file sitting under ${"java.io.tmpdir"}/fakerepo[_{"user.name"}]/${groupid}/{artifactid}/${version}/
    * @throws IOException if the file could not be created
    */
   private File fakeFile(ArtifactRepository localRepo, Artifact artifact) throws IOException {
-    File fakeRepo = new File(System.getProperty("java.io.tmpdir"), "fakerepo");
+    // The path to the fake repo should be unique for each user of a system
+    String userName = System.getProperty("user.name");
+    String subDirSuffix = (userName != null) ? ("_" + userName) : ("");
+    File fakeRepo = new File(System.getProperty("java.io.tmpdir"), "fakerepo" + subDirSuffix);
   
     File fakeFile = new File(fakeRepo, localRepo.pathOf(artifact));
     File parent = fakeFile.getParentFile();


### PR DESCRIPTION
On a multi-user system Eclipse might report a "permission denied"
message for a `pom.xml` file. This is known to be caused by
a workaround in mavenarchiver. For more details, see
https://dev.eclipse.org/mhonarc/lists/m2e-users/msg04160.html

mavenarchiver creates a directory `fakerepo/` in `${"java.io.tmpdir"}`
with 755 permissions in Linux. As a result, other users will not be
able to write to this directory.

This changset fixes the issue by assigning a unique fake repo
directory for a user based on `${"user.name"}`.

The corresponding issue is #10.